### PR TITLE
add maximum size limit for texture dimensions and fix build error cau…

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -634,9 +634,10 @@ impl State {
     // Keeps state in sync with window size when changed
     pub fn resize(&mut self, new_size: winit::dpi::PhysicalSize<u32>) {
         if new_size.width > 0 && new_size.height > 0 {
-            self.size = new_size;
-            self.config.width = new_size.width;
-            self.config.height = new_size.height;
+            self.size =
+                winit::dpi::PhysicalSize::new(new_size.width.min(8192), new_size.height.min(8192));
+            self.config.width = self.size.width;
+            self.config.height = self.size.height;
             self.surface.configure(&self.device, &self.config);
             // Make sure to current window size to depth texture - required for calc
             self.depth_texture =

--- a/src/texture.rs
+++ b/src/texture.rs
@@ -19,8 +19,8 @@ impl Texture {
         label: &str,
     ) -> Self {
         let size = wgpu::Extent3d {
-            width: config.width,
-            height: config.height,
+            width: config.width.min(8192),
+            height: config.height.min(8192),
             depth_or_array_layers: 1,
         };
         let desc = wgpu::TextureDescriptor {


### PR DESCRIPTION

### 1.Add .gitkeep
- Add `.gitkeep` file to maintain `assets/models` directory structure
- Fix build error caused by missing models directory

### Why
- Git doesn't track empty directories by default
- The models directory is required for the build process
- `.gitkeep` is a common convention to maintain empty directory structure

### 2. Fix texture size limit overflow

#### Changes
- Add size limit check for depth texture creation
- Limit texture dimensions to 8192x8192 using `min()` function
- Fix potential GPU validation error caused by oversized textures

#### Why
- Previous code allowed unlimited texture dimensions
- GPU has hardware limits for maximum texture size
- Caused validation error: "Dimension X value exceeds the limit of 8192"
